### PR TITLE
:seedling: third_party: track discovery resources per cluster

### DIFF
--- a/kubernetes/typed/core/v1/fake/fake_pod_expansion.go
+++ b/kubernetes/typed/core/v1/fake/fake_pod_expansion.go
@@ -20,7 +20,7 @@ package v1
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -72,7 +72,7 @@ func (c *podsClient) GetLogs(name string, opts *v1.PodLogOptions) *restclient.Re
 		Client: fakerest.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
 			resp := &http.Response{
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader("fake logs")),
+				Body:       io.NopCloser(strings.NewReader("fake logs")),
 			}
 			return resp, nil
 		}),

--- a/third_party/k8s.io/client-go/discovery/fake/discovery.go
+++ b/third_party/k8s.io/client-go/discovery/fake/discovery.go
@@ -52,7 +52,7 @@ func (c *FakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*me
 		Cluster:  c.Cluster,
 	}
 	c.Invokes(action, nil)
-	for _, resourceList := range c.Resources {
+	for _, resourceList := range c.Resources[c.Cluster] {
 		if resourceList.GroupVersion == groupVersion {
 			return resourceList, nil
 		}
@@ -83,7 +83,7 @@ func (c *FakeDiscovery) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav
 		Cluster:  c.Cluster,
 	}
 	c.Invokes(action, nil)
-	return resultGroups, c.Resources, nil
+	return resultGroups, c.Resources[c.Cluster], nil
 }
 
 // ServerPreferredResources returns the supported resources with the version
@@ -110,7 +110,7 @@ func (c *FakeDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
 
 	groups := map[string]*metav1.APIGroup{}
 
-	for _, res := range c.Resources {
+	for _, res := range c.Resources[c.Cluster] {
 		gv, err := schema.ParseGroupVersion(res.GroupVersion)
 		if err != nil {
 			return nil, err

--- a/third_party/k8s.io/client-go/testing/fake.go
+++ b/third_party/k8s.io/client-go/testing/fake.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/kcp-dev/logicalcluster/v2"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -44,7 +46,7 @@ type Fake struct {
 	// for every request in the order they are tried.
 	ProxyReactionChain []ProxyReactor
 
-	Resources []*metav1.APIResourceList
+	Resources map[logicalcluster.Name][]*metav1.APIResourceList
 }
 
 // Reactor is an interface to allow the composition of reaction functions.


### PR DESCRIPTION
kubernetes: move away from ioutil

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

third_party: track discovery resources per cluster

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---
