### PR TITLE
Multi-client factories

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"sync"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+)
+
+// Constructor is a wrapper around a constructor method for the client of type R.
+type Constructor[R any] struct {
+	Provider func(clusterPath logicalcluster.Path) (R, error)
+}
+
+// Cache is a client factory that caches previous results.
+type Cache[R any] interface {
+	ClusterOrDie(clusterPath logicalcluster.Path) R
+	Cluster(clusterPath logicalcluster.Path) (R, error)
+}
+
+// NewCache creates a new factory cache using the given constructor.
+func NewCache[R any](constructor *Constructor[R]) Cache[R] {
+	return &cache[R]{
+		constructor: constructor,
+
+		RWMutex:              &sync.RWMutex{},
+		entriesByClusterPath: map[logicalcluster.Path]R{},
+	}
+}
+
+type cache[R any] struct {
+	constructor *Constructor[R]
+
+	*sync.RWMutex
+	entriesByClusterPath map[logicalcluster.Path]R
+}
+
+// ClusterOrDie returns a new client scoped to the given logical cluster, or panics if there
+// is any error.
+func (c *cache[R]) ClusterOrDie(clusterPath logicalcluster.Path) R {
+	client, err := c.Cluster(clusterPath)
+	if err != nil {
+		// we ensure that the config is valid in the constructor, and we assume that any changes
+		// we make to it during scoping will not make it invalid, in order to hide the error from
+		// downstream callers (as it should forever be nil); this is slightly risky
+		panic(err)
+	}
+	return client
+}
+
+// Cluster returns an entry scoped to the given logical cluster.
+func (c *cache[R]) Cluster(clusterPath logicalcluster.Path) (R, error) {
+	var cached R
+	var exists bool
+	c.RLock()
+	cached, exists = c.entriesByClusterPath[clusterPath]
+	c.RUnlock()
+	if exists {
+		return cached, nil
+	}
+
+	instance, err := c.constructor.Provider(clusterPath)
+	if err != nil {
+		var result R
+		return result, err
+	}
+
+	c.Lock()
+	defer c.Unlock()
+	cached, exists = c.entriesByClusterPath[clusterPath]
+	if exists {
+		return cached, nil
+	}
+
+	c.entriesByClusterPath[clusterPath] = instance
+
+	return instance, nil
+}

--- a/rest/clientset.go
+++ b/rest/clientset.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"fmt"
+	"net/http"
+
+	kcpclient "github.com/kcp-dev/apimachinery/v2/pkg/client"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/flowcontrol"
+)
+
+type ClusterClientset struct {
+	clientCache kcpclient.Cache[rest.Interface]
+}
+
+func (c *ClusterClientset) Cluster(path logicalcluster.Path) rest.Interface {
+	return c.clientCache.ClusterOrDie(path)
+}
+
+var _ ClusterInterface = (*ClusterClientset)(nil)
+
+func NewForConfigAndClient(c *rest.Config, httpClient *http.Client) (*ClusterClientset, error) {
+	configShallowCopy := *c
+	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
+		if configShallowCopy.Burst <= 0 {
+			return nil, fmt.Errorf("burst is required to be greater than 0 when RateLimiter is not set and QPS is set to greater than 0")
+		}
+		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+	}
+
+	cache := kcpclient.NewCache(c, httpClient, &kcpclient.Constructor[rest.Interface]{
+		NewForConfigAndClient: func(cfg *rest.Config, client *http.Client) (rest.Interface, error) {
+			return rest.RESTClientForConfigAndClient(cfg, client)
+		},
+	})
+
+	return &ClusterClientset{clientCache: cache}, nil
+}

--- a/rest/interface.go
+++ b/rest/interface.go
@@ -14,18 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package scale
+package rest
 
 import (
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	"k8s.io/client-go/scale"
+	"k8s.io/client-go/rest"
 )
 
 type ClusterInterface interface {
-	Cluster(logicalcluster.Path) scale.ScalesGetter
-}
-
-type ClusterScaleKindResolver interface {
-	Cluster(path logicalcluster.Path) scale.ScaleKindResolver
+	Cluster(logicalcluster.Path) rest.Interface
 }

--- a/restmapper/clientset.go
+++ b/restmapper/clientset.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restmapper
+
+import (
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/restmapper"
+
+	"github.com/kcp-dev/client-go/cache"
+	clusterdiscovery "github.com/kcp-dev/client-go/discovery"
+)
+
+type DeferredDiscoveryRESTMapper struct {
+	clientCache cache.Cache[meta.RESTMapper]
+}
+
+func (c *DeferredDiscoveryRESTMapper) Cluster(clusterPath logicalcluster.Path) meta.RESTMapper {
+	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+var _ ClusterInterface = (*DeferredDiscoveryRESTMapper)(nil)
+
+func NewDeferredDiscoveryRESTMapper(cl clusterdiscovery.DiscoveryClusterInterface) ClusterInterface {
+	return &DeferredDiscoveryRESTMapper{
+		clientCache: cache.NewCache(&cache.Constructor[meta.RESTMapper]{Provider: func(clusterPath logicalcluster.Path) (meta.RESTMapper, error) {
+			return restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(cl.Cluster(clusterPath))), nil
+		}}),
+	}
+}

--- a/restmapper/interface.go
+++ b/restmapper/interface.go
@@ -14,18 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package scale
+package restmapper
 
 import (
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	"k8s.io/client-go/scale"
+	"k8s.io/apimachinery/pkg/api/meta"
 )
 
 type ClusterInterface interface {
-	Cluster(logicalcluster.Path) scale.ScalesGetter
-}
-
-type ClusterScaleKindResolver interface {
-	Cluster(path logicalcluster.Path) scale.ScaleKindResolver
+	Cluster(logicalcluster.Path) meta.RESTMapper
 }


### PR DESCRIPTION
This is a draft PR that demonstrates reuse of cached clients, like the Discovery one, that's requires to create RESTMapper or Scale clients, which avoids multiplied / duplicated requests, and centralises cache invalidation and refresh.

The idea is to mirror the existing factories from k8s/client-go, with the argument types changed to their cluster interfaces equivalent.

The client cache is duplicated in that draft, but the existing one from `github.com/kcp-dev/apimachinery/v2/pkg/client` could be amended with a generic caching factory method.

This allows to write code, where any client is only instantiated once, e.g.:

```go
discovery, err := discovery.NewForConfig(cfg)
if err != nil {
	return nil, err
}

restClient, err := rest.NewForConfigAndClient(cfg, httpClient)
if err != nil {
	return nil, err
}

restMapper := restmapper.NewDeferredDiscoveryRESTMapper(discovery)

scaleClient := scale.New(restClient,
	restMapper,
	dynamic.LegacyAPIPathResolverFunc, 
	scale.NewDiscoveryScaleKindResolver(discovery),
)

mapping, err := restMapper.Cluster(cluster).
	RESTMapping(object.GetObjectKind().GroupVersionKind().GroupKind())

s, err := scaleClient.Cluster(path).Scales(object.GetNamespace()).
	Get(ctx, mapping.Resource.GroupResource(), object.GetName(), metav1.GetOptions{})
```