### PR TITLE
🌱 Add .prow.yaml to migrate to kcp-prow

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,0 @@
-build_root_image:
-  namespace: ci
-  name: kcp-dev-build-root
-  tag: "1.18"

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,0 +1,26 @@
+presubmits:
+  - name: pull-client-go-verify
+    always_run: true
+    decorate: true
+    clone_uri: "ssh://git@github.com/kcp-dev/client-go.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.19.9-2
+          command:
+            - make
+            - verify
+
+  - name: pull-client-go-lint
+    always_run: true
+    decorate: true
+    clone_uri: "ssh://git@github.com/kcp-dev/client-go.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.19.9-2
+          command:
+            - make
+            - lint

--- a/Makefile
+++ b/Makefile
@@ -73,3 +73,6 @@ verify-codegen:
 		echo "You need to run 'make codegen' to update generated files and commit them"; \
 		exit 1; \
 	fi
+
+.PHONY: verify
+verify: verify-codegen


### PR DESCRIPTION
## Summary

Also add a `verify` target in the Makefile in case we want to introduce any other verify checks in the future.

## Related issue(s)

Fixes https://github.com/kcp-dev/infra/issues/32
Ref: https://github.com/kcp-dev/infra/issues/25
